### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/GPT_Mail_Back_End/basicagent/main.py
+++ b/GPT_Mail_Back_End/basicagent/main.py
@@ -141,7 +141,7 @@ async def run_agent(request: Request):
                 else:
                     err_key = "credentials_load_failed"
                 logging.exception("Credential error for user %s", user)
-                results.append({"user": user, "status": "error", "error": err_key, "message": err_text})
+                results.append({"user": user, "status": "error", "error": err_key, "message": "A credential error occurred for this user."})
             except HttpError as e:
                 # map common Gmail API http errors to safe keys
                 try:
@@ -155,15 +155,15 @@ async def run_agent(request: Request):
                     err_key = "permission_denied"
                 else:
                     err_key = "gmail_api_error"
-                results.append({"user": user, "status": "error", "error": err_key, "message": str(e)})
+                results.append({"user": user, "status": "error", "error": err_key, "message": "An error occurred when contacting Gmail API."})
             except Exception as e:
                 logging.exception("Unexpected error running agent for user %s", user)
-                results.append({"user": user, "status": "error", "error": "agent_failed", "message": str(e)})
+                results.append({"user": user, "status": "error", "error": "agent_failed", "message": "An internal error occurred while drafting emails."})
         # overall response always 200 with per-user statuses so frontend can render friendly messages per user
         return JSONResponse(content={"status": "ok", "results": results}, status_code=200)
     except Exception as e:
         logging.exception("Failed to parse /run-agent request")
-        return JSONResponse(content={"status": "error", "message": str(e)}, status_code=400)
+        return JSONResponse(content={"status": "error", "message": "Failed to parse request. Please check your input and try again."}, status_code=400)
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)


### PR DESCRIPTION
Potential fix for [https://github.com/Samuel-LY-Wang/AI-Agent-Email-Handler/security/code-scanning/9](https://github.com/Samuel-LY-Wang/AI-Agent-Email-Handler/security/code-scanning/9)

To fix the information exposure issue, the code should avoid exposing exception details directly to users. Instead, return a generic error message in the API response, while logging the full error details server-side for debugging and audit. Specifically, in the per-user error reporting (`message`), replace the direct exception string (`err_text` or `str(e)`) with general, non-sensitive messages such as "An internal error occurred" or context-appropriate generic messages. Maintain logging statements for detailed diagnostics, but sanitize the API output.  

Required changes:
- For the block in `run_agent` where per-user errors are appended to results (lines 144, 158, and 161), replace exception text in the `message` with a generic message.
- Optionally, keep any user-visible error keys (like `user_not_authenticated`, `gmail_api_error`) unchanged for the frontend to show localized error displays.
- Do not include exception text in the request-level error response (line 166): replace `str(e)` with a generic message.

No new method imports are required; Python `logging` suffices for server-side diagnostics. Only the relevant regions in `GPT_Mail_Back_End/basicagent/main.py` need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
